### PR TITLE
Added SemVer to the client. 

### DIFF
--- a/UGAPI/UGClient.h
+++ b/UGAPI/UGClient.h
@@ -37,7 +37,7 @@ set the response limit in UGQuery as well.
 
 @interface UGClient : NSObject
 
-+(int) version;
++(NSString *) version;
 
 /********************* INIT AND SETUP *********************/
 // init with an app ID

--- a/UGAPI/UGClient.m
+++ b/UGAPI/UGClient.m
@@ -42,9 +42,9 @@ NSString *g_deviceUUID = nil;
 /************************** ACCESSORS *******************************/
 /************************** ACCESSORS *******************************/
 /************************** ACCESSORS *******************************/
-+(int) version
++(NSString *) version
 {
-    return 1;
+    return @"0.1.1";
 }
 
 -(NSString *)getAccessToken

--- a/test/test_client.nu
+++ b/test/test_client.nu
@@ -26,4 +26,8 @@
     (assert_equal "fred" (object applicationName:))
     (assert_equal "get" (object action:))
     (set entities (object entities:))
-    (assert_equal (object count:) (entities count))))
+    (assert_equal (object count:) (entities count)))
+
+ (- testSemVerOfClient is
+    ;; create a client
+    (assert_equal "0.1.1" (UGClient version))))


### PR DESCRIPTION
1. UGClient version is now 0.1.1. Returned as an `NSString *` now.
2. Also took a small crack a Nu unit tests by adding a super basic test that verifies proper version is returned by the call to `[UGClient version];`.
